### PR TITLE
Change filename extension for scripts/save-project.mjs

### DIFF
--- a/scripts/save-project.js
+++ b/scripts/save-project.js
@@ -2,7 +2,7 @@ const prettier = require("prettier");
 const fs = require("fs");
 const path = require("path");
 const fetch = require("node-fetch");
-import { buffer } from 'buffer';
+const { buffer } = require("buffer")
 
 // The location of the dist directory.
 const DIST_PATH = path.resolve(__dirname, "..", "dist");


### PR DESCRIPTION
This pull request changes the filename of scripts/save-project.mjs to scripts/save-project.js. This probably fixes some errors and will make the action work.

btw i am @FunctionalMetatable just on a new account